### PR TITLE
changed configdir to gnupghome

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you want to change that (or any other parameter), you can pass in options to 
 ```
 ext_pillar:
   - decrypt:
-    - homedir: /path/to/gnupg/homedir
+    - gnupghome: /path/to/gnupg/homedir
     - verbose: True
 ```
 

--- a/decrypt.py
+++ b/decrypt.py
@@ -25,7 +25,8 @@ def _decrypt_value(encrypted_string):
         decrypted_string =  gpg.decrypt(encrypted_string)
         if decrypted_string.data == '':
             raise
-        return yaml.safe_load(decrypted_string.data)
+        #return yaml.safe_load(decrypted_string.data)
+        return decrypted_string.data
     except Exception, e:
         log.exception('Could not decrypt string. Using its encrypted representation.')
         return encrypted_string

--- a/decrypt.py
+++ b/decrypt.py
@@ -5,7 +5,7 @@ import os
 
 log = logging.getLogger(__name__)
 config = {
-    'homedir': '/etc/salt/gpgkeys',
+    'gnupghome': '/etc/salt/gpgkeys',
 }
 
 def ext_pillar(minion_id, pillar, *args, **kwargs):
@@ -18,7 +18,7 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
 def _decrypt_value(encrypted_string):
     try:
         import gnupg
-        if not os.path.isdir(config['homedir']):
+        if not os.path.isdir(config['gnupghome']):
             raise
         gpg = gnupg.GPG(**config)
         gpg.encoding = 'utf-8'


### PR DESCRIPTION
I love that you made this! But when I tried to use it on a Trusty Ubuntu Master and a Centos 7.3 master, salt / python threw errors that it didnt know what homedir was. I looked at python-gnupg and there wasnt an option called homedir. Weird. What are you running for your master ? Anyway, this is what I changed to get it to work.